### PR TITLE
✨ feat: tag folder CRUD implementation

### DIFF
--- a/src/common/functions/arraysEqual.ts
+++ b/src/common/functions/arraysEqual.ts
@@ -1,0 +1,17 @@
+export const arraysEqual = (arr1: any[], arr2: any[]): boolean => {
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+
+  for (let i = 0; i < arr1.length; i++) {
+    if (arr1[i].id !== arr2[i].id) {
+      return false;
+    }
+
+    if (arr1[i].name !== arr2[i].name) {
+      return false;
+    }
+  }
+
+  return true;
+};

--- a/src/entities/tagFolders.entity.ts
+++ b/src/entities/tagFolders.entity.ts
@@ -1,0 +1,34 @@
+import { UserEntity } from './users.entity';
+import {
+  BaseEntity,
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { TagEntity } from './tags.entity';
+
+@Entity('tag_folders')
+export class TagFolderEntity extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column('varchar', { length: 30 })
+  name: string;
+
+  @OneToMany(() => TagEntity, (tag: TagEntity) => tag.folder_id, {
+    cascade: true,
+  })
+  tags: TagEntity[];
+
+  @ManyToOne(() => UserEntity, (user_id: UserEntity) => user_id.tag_folders)
+  @JoinColumn([
+    {
+      name: 'user_id',
+      referencedColumnName: 'id',
+    },
+  ])
+  user_id: UserEntity;
+}

--- a/src/entities/tags.entity.ts
+++ b/src/entities/tags.entity.ts
@@ -3,9 +3,12 @@ import {
   BaseEntity,
   Column,
   Entity,
+  JoinColumn,
   ManyToMany,
+  ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+import { TagFolderEntity } from './tagFolders.entity';
 
 @Entity('tags')
 export class TagEntity extends BaseEntity {
@@ -14,6 +17,18 @@ export class TagEntity extends BaseEntity {
 
   @Column('varchar', { length: 200 })
   name: string;
+
+  @ManyToOne(
+    () => TagFolderEntity,
+    (folder_id: TagFolderEntity) => folder_id.tags,
+  )
+  @JoinColumn([
+    {
+      name: 'folder_id',
+      referencedColumnName: 'id',
+    },
+  ])
+  folder_id: TagFolderEntity;
 
   @ManyToMany(() => PostEntity, (post: PostEntity) => post.tags)
   posts: PostEntity[];

--- a/src/entities/users.entity.ts
+++ b/src/entities/users.entity.ts
@@ -1,0 +1,50 @@
+import { TagFolderEntity } from './tagFolders.entity';
+import {
+  BaseEntity,
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('users')
+export class UserEntity extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ unique: true })
+  github_id: string;
+
+  @Column('varchar', { length: 50 })
+  name: string;
+
+  @Column('varchar', { length: 60, nullable: true })
+  refresh_token: string | null;
+
+  @Column('varchar', { length: 255, nullable: true })
+  description: string;
+
+  @Column('varchar', { length: 255, nullable: true })
+  profile_image: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updated_at: Date;
+
+  @DeleteDateColumn({ type: 'timestamptz' })
+  deleted_at?: Date | null;
+
+  @OneToMany(
+    () => TagFolderEntity,
+    (folder: TagFolderEntity) => folder.user_id,
+    {
+      cascade: true,
+    },
+  )
+  tag_folders: TagFolderEntity[];
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,8 +22,8 @@ async function bootstrap() {
   SwaggerModule.setup('api', app, document);
 
   app.enableCors({
-    origin: true,
-    credentials: true,
+    origin: 'http://localhost:3000',
+    // credentials: true,
   });
 
   await app.listen(PORT);

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -22,20 +22,20 @@ export class PostsController {
 
   @ApiOperation({ summary: '전체 post 조회' })
   @Get()
-  getAllPost() {
-    return this.postsService.getAllPost();
+  async getAllPost() {
+    return await this.postsService.getAllPost();
   }
 
   @ApiOperation({ summary: 'post 상세 조회' })
   @Get(':id')
-  getOnePost(@Param('id', ParseIntPipe) id: number) {
-    return this.postsService.getOnePost(id);
+  async getOnePost(@Param('id', ParseIntPipe) id: number) {
+    return await this.postsService.getOnePost(id);
   }
 
   @ApiOperation({ summary: 'post 등록' })
   @Post()
-  createPost(@Body() body: PostRequestDto) {
-    return this.postsService.createPost(body);
+  async createPost(@Body() body: PostRequestDto) {
+    return await this.postsService.createPost(body);
   }
 
   @ApiOperation({ summary: 'post 수정' })
@@ -58,7 +58,7 @@ export class PostsController {
 
   @ApiOperation({ summary: 'post 삭제' })
   @Delete(':id')
-  deletePost(@Param('id', ParseIntPipe) id: number) {
-    return this.postsService.deletePost(id);
+  async deletePost(@Param('id', ParseIntPipe) id: number) {
+    return await this.postsService.deletePost(id);
   }
 }

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -1,3 +1,5 @@
+import { UserEntity } from './../entities/users.entity';
+import { TagEntity } from 'src/entities/tags.entity';
 import { CategoryEntity } from './../entities/categories.entity';
 import { PostsRepository } from './posts.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -8,7 +10,13 @@ import { PostEntity } from '../entities/posts.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([PostEntity, PostsRepository, CategoryEntity]),
+    TypeOrmModule.forFeature([
+      PostEntity,
+      PostsRepository,
+      CategoryEntity,
+      TagEntity,
+      UserEntity,
+    ]),
   ],
   controllers: [PostsController],
   providers: [PostsService, PostsRepository],

--- a/src/posts/posts.request.dto.ts
+++ b/src/posts/posts.request.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { IsArray, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 
 export class PostRequestDto {
   @ApiProperty({
@@ -20,15 +20,6 @@ export class PostRequestDto {
 
   @ApiProperty({
     example: 1,
-    description: 'user_id',
-    required: true,
-  })
-  @IsNumber()
-  @IsNotEmpty()
-  user_id: number;
-
-  @ApiProperty({
-    example: 1,
     description: 'category_id',
     required: true,
   })
@@ -42,4 +33,7 @@ export class PostRequestDto {
     required: true,
   })
   public_status: boolean;
+
+  @IsArray()
+  tags: string[];
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,5 +1,7 @@
+import { UserEntity } from './../entities/users.entity';
+import { TagEntity } from 'src/entities/tags.entity';
 import { CategoryEntity } from './../entities/categories.entity';
-import { InjectRepository } from '@nestjs/typeorm';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { PostRequestDto } from './posts.request.dto';
 import {
   BadRequestException,
@@ -8,24 +10,31 @@ import {
 } from '@nestjs/common';
 import { PostsRepository } from './posts.repository';
 import { PostEntity } from '../entities/posts.entity';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { arraysEqual } from 'src/common/functions/arraysEqual';
 
 @Injectable()
 export class PostsService {
   constructor(
     @InjectRepository(CategoryEntity)
     private categoriesRepository: Repository<CategoryEntity>,
+    @InjectRepository(TagEntity)
+    private tagsRepository: Repository<TagEntity>,
+    @InjectRepository(UserEntity)
+    private usersRepository: Repository<UserEntity>,
+    @InjectDataSource()
+    private dataSource: DataSource,
     private readonly postsRepository: PostsRepository,
   ) {}
 
   async getAllPost() {
     const user_id = 1; //after complete jwt, insert decoding user_id
 
-    return this.postsRepository.getAllPost(user_id);
+    return await this.postsRepository.getAllPost(user_id);
   }
 
   async getOnePost(id: number): Promise<PostEntity> {
-    const found = this.postsRepository.getOnePost(id);
+    const found = await this.postsRepository.getOnePost(id);
 
     if (!found) {
       throw new NotFoundException(`Can't find post with id: ${id}`);
@@ -35,7 +44,13 @@ export class PostsService {
   }
 
   async createPost(body: PostRequestDto) {
-    const { title, content, user_id, category_id, public_status } = body;
+    const { title, content, category_id, public_status, tags } = body;
+    const user_id = 1;
+    let concatTags: TagEntity[] = [];
+
+    const user = await this.usersRepository.findOne({
+      where: { id: user_id },
+    });
 
     const category = await this.categoriesRepository.findOne({
       where: { id: category_id },
@@ -47,17 +62,45 @@ export class PostsService {
       );
     }
 
-    return await this.postsRepository.createPost(
+    if (tags.length !== 0) {
+      for (const tag_name of tags) {
+        const found = await this.dataSource
+          .getRepository(TagEntity)
+          .createQueryBuilder('tags')
+          .leftJoin('tags.posts', 'posts')
+          .where('posts.user_id = :user', { user: user.id })
+          .andWhere('tags.name = :name', { name: tag_name })
+          .getOne();
+
+        if (found) {
+          concatTags = concatTags.concat(found);
+        } else {
+          const create = await this.tagsRepository.create({
+            name: tag_name,
+          });
+          await this.tagsRepository.save(create);
+
+          concatTags = concatTags.concat(create);
+        }
+      }
+    }
+
+    const result = await this.postsRepository.createPost(
       title,
       content,
       user_id,
       public_status,
       category,
+      concatTags,
     );
+
+    return result;
   }
 
   async updatePost(id: number, body: PostRequestDto) {
-    const { title, content } = body;
+    const { title, content, tags } = body;
+    const user_id = 1;
+    let updateTags: TagEntity[] = [];
 
     const found = await this.postsRepository.getOnePost(id);
 
@@ -65,13 +108,49 @@ export class PostsService {
       throw new NotFoundException(`Can't not find post with id: ${id}`);
     }
 
+    const user = await this.usersRepository.findOne({
+      where: { id: user_id },
+    });
+
+    if (tags.length !== 0) {
+      for (const tag_name of tags) {
+        const found = await this.dataSource
+          .getRepository(TagEntity)
+          .createQueryBuilder('tags')
+          .leftJoin('tags.posts', 'posts')
+          .where('posts.user_id = :user', { user: user.id })
+          .andWhere('tags.name = :name', { name: tag_name })
+          .getOne();
+
+        if (found) {
+          updateTags = updateTags.concat(found);
+        } else {
+          const create = await this.tagsRepository.create({
+            name: tag_name,
+          });
+          await this.tagsRepository.save(create);
+
+          updateTags = updateTags.concat(create);
+        }
+      }
+    }
+
     const modifyCheck = await this.postsRepository.getOnePost(id);
 
-    if (modifyCheck.title === title && modifyCheck.content === content) {
+    if (
+      modifyCheck.title === title &&
+      modifyCheck.content === content &&
+      arraysEqual(updateTags, modifyCheck.tags)
+    ) {
       throw new BadRequestException('No modifications have been made');
     }
 
-    return await this.postsRepository.updatePost(id, title, content);
+    return await this.postsRepository.updatePost(
+      id,
+      title,
+      content,
+      updateTags,
+    );
   }
 
   async updatePartialPost(id: number, public_status: boolean) {

--- a/src/tag_folders/tag_folder.request.dto.ts
+++ b/src/tag_folders/tag_folder.request.dto.ts
@@ -1,0 +1,9 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class TagFolderRequestDto {
+  @IsOptional()
+  id: number;
+
+  @IsString()
+  name: string;
+}

--- a/src/tag_folders/tag_folders.controller.spec.ts
+++ b/src/tag_folders/tag_folders.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TagFoldersController } from './tag_folders.controller';
+
+describe('TagFoldersController', () => {
+  let controller: TagFoldersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TagFoldersController],
+    }).compile();
+
+    controller = module.get<TagFoldersController>(TagFoldersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/tag_folders/tag_folders.controller.ts
+++ b/src/tag_folders/tag_folders.controller.ts
@@ -1,0 +1,54 @@
+import { SuccessInterceptor } from './../common/interceptors/success.interceptor';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+  UseInterceptors,
+} from '@nestjs/common';
+import { TagFoldersService } from './tag_folders.service';
+import { ApiOperation } from '@nestjs/swagger';
+import { TagFolderRequestDto } from './tag_folder.request.dto';
+
+@Controller('tag_folders')
+@UseInterceptors(SuccessInterceptor)
+export class TagFoldersController {
+  constructor(private readonly tagFoldersService: TagFoldersService) {}
+
+  @ApiOperation({ summary: 'tag folder 전체 조회' })
+  @Get()
+  async getAllFolder() {
+    return await this.tagFoldersService.getAllFolder();
+  }
+
+  @ApiOperation({ summary: 'tag folder 상세 조회' })
+  @Get(':id')
+  async getOneFolder() {
+    return await this.tagFoldersService.getOneFolder();
+  }
+
+  @ApiOperation({ summary: 'tag folder 등록' })
+  @Post()
+  async createFolder(@Body() body: TagFolderRequestDto) {
+    return await this.tagFoldersService.createFolder(body);
+  }
+
+  @ApiOperation({ summary: 'tag folder 이름 수정' })
+  @Put(':id')
+  async updateFolder(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: TagFolderRequestDto,
+  ) {
+    return await this.tagFoldersService.updateFolder(id, body);
+  }
+
+  @ApiOperation({ summary: 'tag folder 삭제' })
+  @Delete(':id')
+  async deleteFolder(@Param('id', ParseIntPipe) id: number) {
+    return await this.tagFoldersService.deleteFolder(id);
+  }
+}

--- a/src/tag_folders/tag_folders.module.ts
+++ b/src/tag_folders/tag_folders.module.ts
@@ -1,4 +1,23 @@
+import { TagEntity } from 'src/entities/tags.entity';
+import { UserEntity } from './../entities/users.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { Module } from '@nestjs/common';
+import { TagFolderEntity } from 'src/entities/tagFolders.entity';
+import { TagFoldersController } from './tag_folders.controller';
+import { TagFoldersRepository } from './tag_folders.repository';
+import { TagFoldersService } from './tag_folders.service';
 
-@Module({})
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      TagFolderEntity,
+      TagFoldersRepository,
+      TagFolderEntity,
+      UserEntity,
+      TagEntity,
+    ]),
+  ],
+  controllers: [TagFoldersController],
+  providers: [TagFoldersService, TagFoldersRepository],
+})
 export class TagFoldersModule {}

--- a/src/tag_folders/tag_folders.repository.ts
+++ b/src/tag_folders/tag_folders.repository.ts
@@ -1,0 +1,73 @@
+import { TagFolderEntity } from './../entities/tagFolders.entity';
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { UserEntity } from 'src/entities/users.entity';
+
+@Injectable()
+export class TagFoldersRepository {
+  constructor(
+    @InjectRepository(TagFolderEntity)
+    private tagFoldersRepository: Repository<TagFolderEntity>,
+    @InjectDataSource()
+    private dataSource: DataSource,
+  ) {}
+
+  async getAllFolder(user_id: number) {
+    return await this.dataSource
+      .getRepository(TagFolderEntity)
+      .createQueryBuilder('tag_folders')
+      .where('tag_folders.user_id = :user_id', { user_id })
+      .leftJoinAndSelect('tag_folders.tags', 'tags')
+      .leftJoin('tags.posts', 'posts')
+      // .where('posts.user_id = :user_id', { user_id })
+      .orderBy('tag_folders.name', 'ASC')
+      .loadRelationCountAndMap('tags.postsCount', 'tags.posts')
+      .loadRelationCountAndMap('tag_folders.tagsCount', 'tag_folders.tags')
+      .getMany();
+  }
+
+  async getOneFolderByUserId(name: string, user: UserEntity) {
+    return await this.tagFoldersRepository.findOne({
+      where: {
+        name,
+        user_id: {
+          id: user.id,
+        },
+      },
+    });
+  }
+
+  async getOneFolderById(id: number, user: UserEntity) {
+    return await this.tagFoldersRepository.findOne({
+      where: {
+        id,
+        user_id: {
+          id: user.id,
+        },
+      },
+    });
+  }
+
+  async createFolder(name: string, user: UserEntity) {
+    const folder = await this.tagFoldersRepository.create({
+      name,
+    });
+
+    folder.user_id = user;
+
+    await this.tagFoldersRepository.save(folder);
+
+    return folder;
+  }
+
+  async updateFolder(id: number, name: string) {
+    return await this.tagFoldersRepository.update(id, {
+      name,
+    });
+  }
+
+  async deleteFolder(id: number) {
+    return await this.tagFoldersRepository.delete(id);
+  }
+}

--- a/src/tag_folders/tag_folders.service.spec.ts
+++ b/src/tag_folders/tag_folders.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TagFoldersService } from './tag_folders.service';
+
+describe('TagFoldersService', () => {
+  let service: TagFoldersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TagFoldersService],
+    }).compile();
+
+    service = module.get<TagFoldersService>(TagFoldersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/tag_folders/tag_folders.service.ts
+++ b/src/tag_folders/tag_folders.service.ts
@@ -1,0 +1,106 @@
+import { TagEntity } from 'src/entities/tags.entity';
+import { TagFolderRequestDto } from './tag_folder.request.dto';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { TagFoldersRepository } from './tag_folders.repository';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserEntity } from 'src/entities/users.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class TagFoldersService {
+  constructor(
+    @InjectRepository(UserEntity)
+    private usersRepository: Repository<UserEntity>,
+    private readonly tagFoldersRepository: TagFoldersRepository,
+    @InjectRepository(TagEntity)
+    private tagRepository: Repository<TagEntity>,
+  ) {}
+
+  async getAllFolder() {
+    const user_id = 1;
+
+    return await this.tagFoldersRepository.getAllFolder(user_id);
+  }
+
+  async getOneFolder() {
+    // return await this.tagFoldersRepository.getOneFolder();
+  }
+
+  async createFolder(body: TagFolderRequestDto) {
+    const { name } = body;
+    const user_id = 2;
+
+    const user = await this.usersRepository.findOne({
+      where: { id: user_id },
+    });
+
+    if (!user) {
+      throw new NotFoundException(`Can't find user with user_id: ${user_id}`);
+    }
+
+    const found = await this.tagFoldersRepository.getOneFolderByUserId(
+      name,
+      user,
+    );
+
+    if (found) {
+      throw new BadRequestException(`${name} folder is already folder name`);
+    }
+
+    return await this.tagFoldersRepository.createFolder(name, user);
+  }
+
+  async updateFolder(id: number, body: TagFolderRequestDto) {
+    const { name } = body;
+    const user_id = 1;
+
+    const user = await this.usersRepository.findOne({
+      where: { id: user_id },
+    });
+
+    const found = await this.tagFoldersRepository.getOneFolderById(id, user);
+
+    if (!found) {
+      throw new NotFoundException(`Can't find tag folder with id: ${id}`);
+    }
+
+    return await this.tagFoldersRepository.updateFolder(id, name);
+  }
+
+  async deleteFolder(id: number) {
+    const user_id = 1;
+
+    const user = await this.usersRepository.findOne({
+      where: { id: user_id },
+    });
+
+    const found = await this.tagFoldersRepository.getOneFolderById(id, user);
+
+    if (!found) {
+      throw new NotFoundException(`Can't find tag folder with id: ${id}`);
+    }
+
+    const foundRelations = await this.tagRepository.findAndCount({
+      where: {
+        folder_id: {
+          user_id: {
+            id: user.id,
+          },
+        },
+      },
+      relations: {
+        folder_id: true,
+      },
+    });
+
+    if (foundRelations[foundRelations.length - 1]) {
+      throw new BadRequestException(`id:${id} Folder is not empty`);
+    }
+
+    return await this.tagFoldersRepository.deleteFolder(id);
+  }
+}

--- a/src/tags/tag.request.dto.ts
+++ b/src/tags/tag.request.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class TagRequestDto {
+  @IsString()
+  name: string;
+}

--- a/src/tags/tags.controller.ts
+++ b/src/tags/tags.controller.ts
@@ -1,7 +1,8 @@
 import { TagsService } from './tags.service';
-import { Controller, Get, UseInterceptors } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseInterceptors } from '@nestjs/common';
 import { SuccessInterceptor } from 'src/common/interceptors/success.interceptor';
 import { ApiOperation } from '@nestjs/swagger';
+import { TagRequestDto } from './tag.request.dto';
 
 @Controller('tags')
 @UseInterceptors(SuccessInterceptor)
@@ -14,5 +15,13 @@ export class TagsController {
     const user_id = 1;
 
     return this.tagsService.getAllTag(user_id);
+  }
+
+  @ApiOperation({ summary: 'tag 생성' })
+  @Post()
+  createTag(@Body() body: TagRequestDto) {
+    const user_id = 1;
+
+    return this.tagsService.createTag(user_id, body);
   }
 }

--- a/src/tags/tags.module.ts
+++ b/src/tags/tags.module.ts
@@ -4,9 +4,10 @@ import { TagsController } from './tags.controller';
 import { TagsService } from './tags.service';
 import { TagEntity } from 'src/entities/tags.entity';
 import { TagsRepository } from './tags.repository';
+import { UserEntity } from 'src/entities/users.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([TagEntity, TagsRepository])],
+  imports: [TypeOrmModule.forFeature([TagEntity, TagsRepository, UserEntity])],
   controllers: [TagsController],
   providers: [TagsService, TagsRepository],
 })

--- a/src/tags/tags.repository.ts
+++ b/src/tags/tags.repository.ts
@@ -2,6 +2,7 @@ import { TagEntity } from './../entities/tags.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
+import { UserEntity } from 'src/entities/users.entity';
 
 @Injectable()
 export class TagsRepository {
@@ -9,11 +10,11 @@ export class TagsRepository {
     @InjectRepository(TagEntity)
     private tagsRepository: Repository<TagEntity>,
     @InjectDataSource()
-    private datasource: DataSource,
+    private dataSource: DataSource,
   ) {}
 
   async getAllTag(user_id) {
-    return await this.datasource
+    return await this.dataSource
       .getRepository(TagEntity)
       .createQueryBuilder('tags')
       .leftJoin('tags.posts', 'posts')
@@ -21,5 +22,25 @@ export class TagsRepository {
       .orderBy('tags.name', 'ASC')
       .loadRelationCountAndMap('tags.postsCount', 'tags.posts')
       .getMany();
+  }
+
+  async getOneTag(user: UserEntity, name: string) {
+    return await this.dataSource
+      .getRepository(TagEntity)
+      .createQueryBuilder('tags')
+      .leftJoin('tags.posts', 'posts')
+      .where('posts.user_id = :user', { user: user.id })
+      .andWhere('tags.name = :name', { name })
+      .getOne();
+  }
+
+  async createTag(name: string) {
+    const tag = await this.tagsRepository.create({
+      name,
+    });
+
+    await this.tagsRepository.save(tag);
+
+    return tag;
   }
 }

--- a/src/tags/tags.service.ts
+++ b/src/tags/tags.service.ts
@@ -1,11 +1,46 @@
-import { Injectable } from '@nestjs/common';
+import { TagRequestDto } from './tag.request.dto';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserEntity } from 'src/entities/users.entity';
+import { Repository } from 'typeorm';
 import { TagsRepository } from './tags.repository';
 
 @Injectable()
 export class TagsService {
-  constructor(private readonly tagsRepository: TagsRepository) {}
+  constructor(
+    @InjectRepository(UserEntity)
+    private userRepository: Repository<UserEntity>,
+    private readonly tagsRepository: TagsRepository,
+  ) {}
 
   async getAllTag(user_id) {
-    return this.tagsRepository.getAllTag(user_id);
+    return await this.tagsRepository.getAllTag(user_id);
+  }
+
+  async createTag(user_id: number, body: TagRequestDto) {
+    const { name } = body;
+    const user = await this.userRepository.findOne({
+      where: { id: user_id },
+    });
+
+    if (!user) {
+      throw new NotFoundException(`Can't find user with user_id: ${user_id}`);
+    }
+
+    const found = await this.tagsRepository.getOneTag(user, name);
+    console.log(user);
+    console.log(found);
+
+    return found;
+
+    if (found) {
+      throw new BadRequestException(`${name} tag is already tag name`);
+    }
+
+    return await this.tagsRepository.createTag(name);
   }
 }


### PR DESCRIPTION
## 연관 이슈

<!-- 연관된 이슈의 링크와 내용을 아래 기입하세요(ex: Jira, Sentry 등의 이슈 링크) -->
[Jira : LOG-66] = https://cvlog.atlassian.net/browse/LOG-66
## 풀리퀘스트 유형

<!-- [x] 로 체크 -->

- [ ] 버그수정
- [x] 기능추가
- [x] 기능개선
- [ ] 기능삭제
- [ ] 리팩토링
- [ ] 기타 (우측에 설명기입): 

## 구현 사항

- tag folder CRUD 기능구현 :
 1. tag folder GET : folder에 포함된 tag의 수를 count하여 포함하고 각 tag에 post의 count를 포함한다.
 2. tag folder POST : name 입력받아 중복 체크 후 생성한다.
 3. tag folder PUT : name 입력받아 중복 체크 후 수정한다.
 4. tag folder DELETE : 폴더가 비어져 있는지 체크 후 삭제한다.
 
- post create, update 기능개선:
 1. tags를 입력받아 post 생성 과정에 tag들이 생성될 수 있도록 개선.
 5. post 업데이트 과정에서도 동일하게 업데이트 기능이 되도록 개선.

## 특이사항
회원가입 / 로그인 기능 중 jwt이 구현 여부에 따라 내 태그 전체 리스트 및 포함된 게시물 카운트 조회에서 하드코딩 되어있는 user_id 부분을 수정 예정. (user_id = 1 -> jwt를 decode 하여 user_id를 추출하여 대체)