### PR TITLE
💄 style: Modify logic of getting user information

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,14 +1,13 @@
-import { 
+import {
   Controller,
   Get,
   Header,
   Headers,
   Post,
   Query,
-  Req,
   Res,
   UseGuards,
-  UseInterceptors
+  UseInterceptors,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { ApiOperation } from '@nestjs/swagger';
@@ -23,13 +22,19 @@ import { GetUser } from './auth.decorator';
 @UseInterceptors(SuccessInterceptor)
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
-  
+
   @ApiOperation({ summary: 'user 회원가입 및 로그인' })
   @Get('login')
-  public async getGithubInfo(@Query() githubCodeDto: GithubCodeDto, @Res({ passthrough: true }) res: Response) : Promise<{ accessToken: string }> {
+  public async getGithubInfo(
+    @Query() githubCodeDto: GithubCodeDto,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<{ accessToken: string }> {
     await this.authService.getGithubInfo;
-    const accessToken = await this.authService.getGithubInfo(githubCodeDto, res);
-    
+    const accessToken = await this.authService.getGithubInfo(
+      githubCodeDto,
+      res,
+    );
+
     return accessToken;
   }
 
@@ -41,14 +46,14 @@ export class AuthController {
     @Res({ passthrough: true }) res: Response,
     @Headers('refreshToken') refreshToken: string,
     @GetUser() user: UserEntity,
-  ) { 
-    if( this.authService.validationRefreshToken(refreshToken, user.github_id) ) {
+  ) {
+    if (this.authService.validationRefreshToken(refreshToken, user.github_id)) {
       const accessToken = await this.authService.createAccessToken(user.id);
-      
+
       return accessToken;
     }
   }
-  
+
   @ApiOperation({ summary: 'user 로그아웃' })
   @Get('/logout')
   @UseGuards(JwtRefreshTokenGuard)

--- a/src/auth/auth.decorator.ts
+++ b/src/auth/auth.decorator.ts
@@ -1,8 +1,10 @@
-import { createParamDecorator, ExecutionContext } from "@nestjs/common";
-import { UserEntity } from "../entities/users.entity";
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { UserEntity } from '../entities/users.entity';
 
-export const GetUser = createParamDecorator((data,ctx: ExecutionContext): UserEntity => {
-  const req = ctx.switchToHttp().getRequest();
-    
-  return req.user;
-})
+export const GetUser = createParamDecorator(
+  (data, ctx: ExecutionContext): UserEntity => {
+    const req = ctx.switchToHttp().getRequest();
+
+    return req.user;
+  },
+);

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -14,13 +14,14 @@ import { JwtRefreshTokenGuard } from './guards/jwt-refresh-token.guard';
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.register({
       secret: process.env.JWT_ACCESS_TOKEN_SECRET_KEY,
-      signOptions:{
-        expiresIn: process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME
-      }
+      signOptions: {
+        expiresIn: process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME,
+      },
     }),
-    TypeOrmModule.forFeature([UserEntity,UsersRepository])],
-    exports: [AuthService, PassportModule],
-    controllers: [AuthController],
-    providers: [AuthService, UsersRepository, JwtRefreshTokenGuard]
+    TypeOrmModule.forFeature([UserEntity, UsersRepository]),
+  ],
+  exports: [AuthService, PassportModule],
+  controllers: [AuthController],
+  providers: [AuthService, UsersRepository, JwtRefreshTokenGuard],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -2,7 +2,7 @@ import {
   BadRequestException,
   Injectable,
   Res,
-  UnauthorizedException
+  UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import axios, { AxiosResponse } from 'axios';
@@ -14,12 +14,12 @@ import { Response } from 'express';
 export class AuthService {
   constructor(
     private readonly usersRepository: UsersRepository,
-    private jwtService: JwtService
-  ){}
+    private jwtService: JwtService,
+  ) {}
 
   public async getGithubInfo(
-  githubCodeDto: GithubCodeDto,
-  @Res({ passthrough: true }) res: Response
+    githubCodeDto: GithubCodeDto,
+    @Res({ passthrough: true }) res: Response,
   ): Promise<{ accessToken: string }> {
     const { code } = githubCodeDto;
     const getTokenUrl = 'https://github.com/login/oauth/access_token';
@@ -33,7 +33,7 @@ export class AuthService {
     const response: AxiosResponse = await axios.post(getTokenUrl, request, {
       headers: {
         accept: 'application/json',
-      }
+      },
     });
 
     if (response.data.error) {
@@ -41,9 +41,9 @@ export class AuthService {
     }
 
     const { access_token } = response.data;
-    
+
     const getUserUrl = 'https://api.github.com/user';
-    
+
     const { data } = await axios.get(getUserUrl, {
       headers: {
         Authorization: `token ${access_token}`,
@@ -51,68 +51,69 @@ export class AuthService {
     });
 
     const { login, avatar_url, name, bio, company } = data;
-    
+
     const githubInfo: GithubUserDto = {
       githubId: login,
       avatar: avatar_url,
       name,
       description: bio,
-      location: company
+      location: company,
     };
-    
-    const githubId = githubInfo.githubId; 
-    const getUserIdByUserGithubId = await this.usersRepository.getOneUserByGithubId(githubId);
+
+    const githubId = githubInfo.githubId;
+    const getUserIdByUserGithubId =
+      await this.usersRepository.getOneUserByGithubId(githubId);
     const id = getUserIdByUserGithubId?.id;
     const accessToken = await this.createAccessToken(id);
     const refreshToken = await this.createRefreshToken(id);
     const found = await this.usersRepository.getOneUserByGithubId(githubId);
-    
-      if(!found){
-        await this.usersRepository.createUser(
-          githubInfo.name,
-          githubId,
-          refreshToken,
-          githubInfo.description,
-          githubInfo.avatar
-        );
+
+    if (!found) {
+      await this.usersRepository.createUser(
+        githubInfo.name,
+        githubId,
+        refreshToken,
+        githubInfo.description,
+        githubInfo.avatar,
+      );
     }
 
     res.cookie('refreshToken', refreshToken, {
       httpOnly: true,
-      maxAge: parseInt(process.env.JWT_REFRESH_TOKEN_EXPIRATION_TIME)
+      maxAge: parseInt(process.env.JWT_REFRESH_TOKEN_EXPIRATION_TIME),
     });
 
     return accessToken;
   }
-  
-  async createAccessToken(id: number): Promise<{ accessToken: string }>{
+
+  async createAccessToken(id: number): Promise<{ accessToken: string }> {
     const payload = { id };
-    const accessToken= await this.jwtService.sign(payload);
+    const accessToken = await this.jwtService.sign(payload);
 
     return { accessToken };
   }
 
   async createRefreshToken(id: number) {
     const payload = { id };
+
     const refreshToken = await this.jwtService.sign(payload, {
       secret: process.env.JWT_REFRESH_TOKEN_SECRET_KEY,
-      expiresIn: process.env.JWT_REFRESH_TOKEN_EXPIRATION_TIME
+      expiresIn: process.env.JWT_REFRESH_TOKEN_EXPIRATION_TIME,
     });
-    
+
     await this.usersRepository.updateRefreshTokenInUser(id, refreshToken);
 
     return refreshToken;
   }
 
-  async validationRefreshToken( refreshToken: string, github_id: string ){
+  async validationRefreshToken(refreshToken: string, github_id: string) {
     const user = await this.usersRepository.getOneUserByGithubId(github_id);
-    if(refreshToken !== user.refresh_token){
-      throw new UnauthorizedException(
-        'error.refreshTokenvailed'
-      );
-    } 
 
-    return true;    
+    if (refreshToken !== user.refresh_token) {
+      throw new UnauthorizedException('error.refreshTokenvailed');
+    }
+
+    return true;
   }
 
   async getCookiesForLogOut() {
@@ -122,7 +123,7 @@ export class AuthService {
         path: '/',
         httpOnly: 'true',
         maxAge: 0,
-      }
+      },
     };
   }
 
@@ -131,29 +132,19 @@ export class AuthService {
     await this.usersRepository.deleteRefreshTokenInUser(id, refreshToken);
   }
 
-  async validationAccessToken(
-    accessToken: string,
-    ignoreExpiration?:boolean
-  ) {
-    try{
-      const payload = await this.jwtService.verifyAsync(
-        accessToken,
-        { ignoreExpiration }
-      );
+  async validationAccessToken(accessToken: string, ignoreExpiration?: boolean) {
+    try {
+      const payload = await this.jwtService.verifyAsync(accessToken, {
+        ignoreExpiration,
+      });
 
       return payload;
     } catch (error) {
       if (error.name === 'TokenExpiredError') {
-        throw new UnauthorizedException(
-          'error.expiredToken'
-        );
-      }
-      else if ( error.name === 'JsonWebTokenError') {
-        throw new UnauthorizedException(
-          'error.invailedToken'
-        );
-       }
-      else {
+        throw new UnauthorizedException('error.expiredToken');
+      } else if (error.name === 'JsonWebTokenError') {
+        throw new UnauthorizedException('error.invailedToken');
+      } else {
         throw error;
       }
     }

--- a/src/auth/guards/auth.guard.ts
+++ b/src/auth/guards/auth.guard.ts
@@ -1,29 +1,42 @@
-import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
-import { Request, Response } from 'express';
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Request } from 'express';
+import { UserEntity } from 'src/entities/users.entity';
+import { Repository } from 'typeorm';
 import { AuthService } from '../auth.service';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
   constructor(
-    private readonly authService: AuthService
-  ){}
+    private readonly authService: AuthService,
+    @InjectRepository(UserEntity)
+    private readonly usersRepository: Repository<UserEntity>,
+  ) {}
 
-  async canActivate(context: ExecutionContext):Promise<boolean> {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const host = context.switchToHttp();
     const req = host.getRequest<Request>();
 
-    const accessToken = typeof req.headers.authorization === 'string' &&
-     /^Bearer/.test(req.headers.authorization)
-    ? req.headers.authorization.split(' ')[1]
-    : null;
+    const accessToken =
+      typeof req.headers.authorization === 'string' &&
+      /^Bearer/.test(req.headers.authorization)
+        ? req.headers.authorization.split(' ')[1]
+        : null;
 
-    if ( accessToken === null ){
+    if (accessToken === null) {
       throw new UnauthorizedException('accessToken is null');
     }
 
     const payload = await this.authService.validationAccessToken(accessToken);
-    req.user = payload.id;
-    
+    req.user = await this.usersRepository.findOne({
+      where: { id: payload.id },
+    });
+
     return true;
   }
 }

--- a/src/auth/guards/jwt-refresh-token.guard.ts
+++ b/src/auth/guards/jwt-refresh-token.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
-@Injectable() 
+@Injectable()
 export class JwtRefreshTokenGuard extends AuthGuard('jwt') {}

--- a/src/entities/posts.entity.ts
+++ b/src/entities/posts.entity.ts
@@ -47,7 +47,7 @@ export class PostEntity extends BaseEntity {
       referencedColumnName: 'id',
     },
   ])
-  user_id: number;
+  user_id: UserEntity;
 
   @ManyToOne(
     () => CategoryEntity,

--- a/src/entities/users.entity.ts
+++ b/src/entities/users.entity.ts
@@ -51,12 +51,8 @@ export class UserEntity extends BaseEntity {
   )
   tag_folders: TagFolderEntity[];
 
-  @OneToMany(
-    () => PostEntity,
-    (post: PostEntity) => post.user_id,
-    {
-      cascade: true,
-    },
-  )
+  @OneToMany(() => PostEntity, (post: PostEntity) => post.user_id, {
+    cascade: true,
+  })
   posts: PostEntity[];
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ async function bootstrap() {
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
-  
+
   app.enableCors({
     origin: 'http://localhost:3000',
   });

--- a/src/posts/posts.repository.ts
+++ b/src/posts/posts.repository.ts
@@ -5,6 +5,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Injectable } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { FileEntity } from 'src/entities/files.entity';
+import { UserEntity } from 'src/entities/users.entity';
 
 @Injectable()
 export class PostsRepository {
@@ -32,7 +33,7 @@ export class PostsRepository {
   async createPost(
     title: string,
     content: string,
-    user_id: number,
+    user: UserEntity,
     public_status: boolean,
     category: CategoryEntity,
     concatTags: TagEntity[],
@@ -41,7 +42,7 @@ export class PostsRepository {
     const post = this.postsRepository.create({
       title,
       content,
-      user_id,
+      user_id: user,
       public_status,
     });
 
@@ -122,16 +123,5 @@ export class PostsRepository {
     await this.filesRepository.save(file);
 
     return file;
-  }
-
-  async updateFile(id: number, fileName: string) {
-    const post = await this.postsRepository.findOne({
-      where: { id },
-      relations: {
-        files: true,
-      },
-    });
-
-    return 'upload File';
   }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -31,8 +31,8 @@ export class PostsService {
     private readonly awsService: AwsService,
   ) {}
 
-  async getAllPost() {
-    const user_id = 1; //after complete jwt, insert decoding user_id
+  async getAllPost(user: UserEntity) {
+    const user_id = user.id;
 
     return await this.postsRepository.getAllPost(user_id);
   }
@@ -47,15 +47,11 @@ export class PostsService {
     return found;
   }
 
-  async createPost(body: PostRequestDto) {
+  async createPost(body: PostRequestDto, user: UserEntity) {
     const { title, content, category_id, public_status, tags, files } = body;
-    const user_id = 1;
+
     let concatTags: TagEntity[] = [];
     let concatFiles: FileEntity[] = [];
-
-    const user = await this.usersRepository.findOne({
-      where: { id: user_id },
-    });
 
     const category = await this.categoriesRepository.findOne({
       where: { id: category_id },
@@ -113,7 +109,7 @@ export class PostsService {
     const result = await this.postsRepository.createPost(
       title,
       content,
-      user_id,
+      user,
       public_status,
       category,
       concatTags,
@@ -123,9 +119,9 @@ export class PostsService {
     return result;
   }
 
-  async updatePost(id: number, body: PostRequestDto) {
+  async updatePost(id: number, body: PostRequestDto, user: UserEntity) {
     const { title, content, tags, files } = body;
-    const user_id = 1;
+
     let updateTags: TagEntity[] = [];
     let concatFiles: FileEntity[] = [];
 
@@ -134,10 +130,6 @@ export class PostsService {
     if (!found) {
       throw new NotFoundException(`Can't find post with id: ${id}`);
     }
-
-    const user = await this.usersRepository.findOne({
-      where: { id: user_id },
-    });
 
     if (tags.length !== 0) {
       for (const tag_name of tags) {
@@ -173,7 +165,7 @@ export class PostsService {
           .andWhere('files.key = :key', { key: key })
           .getOne();
 
-        if (found.post_id !== null && found.post_id.user_id !== user.id) {
+        if (found.post_id !== null && found.post_id.user_id !== user) {
           throw new BadRequestException(
             `${fileUrl} file does not belong to id: ${user.id} user `,
           );

--- a/src/tag_folders/tag_folders.controller.ts
+++ b/src/tag_folders/tag_folders.controller.ts
@@ -9,28 +9,36 @@ import {
   ParseIntPipe,
   Post,
   Put,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { TagFoldersService } from './tag_folders.service';
 import { ApiOperation } from '@nestjs/swagger';
 import { TagFolderRequestDto } from './tag_folder.request.dto';
+import { JwtAuthGuard } from 'src/auth/guards/auth.guard';
+import { GetUser } from 'src/auth/auth.decorator';
+import { UserEntity } from 'src/entities/users.entity';
 
 @SkipThrottle()
 @Controller('tag_folders')
 @UseInterceptors(SuccessInterceptor)
+@UseGuards(JwtAuthGuard)
 export class TagFoldersController {
   constructor(private readonly tagFoldersService: TagFoldersService) {}
 
   @ApiOperation({ summary: 'tag folder 전체 조회' })
   @Get()
-  async getAllFolder() {
-    return await this.tagFoldersService.getAllFolder();
+  async getAllFolder(@GetUser() user: UserEntity) {
+    return await this.tagFoldersService.getAllFolder(user);
   }
 
   @ApiOperation({ summary: 'tag folder 등록' })
   @Post()
-  async createFolder(@Body() body: TagFolderRequestDto) {
-    return await this.tagFoldersService.createFolder(body);
+  async createFolder(
+    @Body() body: TagFolderRequestDto,
+    @GetUser() user: UserEntity,
+  ) {
+    return await this.tagFoldersService.createFolder(body, user);
   }
 
   @ApiOperation({ summary: 'tag folder 이름 수정' })
@@ -38,13 +46,17 @@ export class TagFoldersController {
   async updateFolder(
     @Param('id', ParseIntPipe) id: number,
     @Body() body: TagFolderRequestDto,
+    @GetUser() user: UserEntity,
   ) {
-    return await this.tagFoldersService.updateFolder(id, body);
+    return await this.tagFoldersService.updateFolder(id, body, user);
   }
 
   @ApiOperation({ summary: 'tag folder 삭제' })
   @Delete(':id')
-  async deleteFolder(@Param('id', ParseIntPipe) id: number) {
-    return await this.tagFoldersService.deleteFolder(id);
+  async deleteFolder(
+    @Param('id', ParseIntPipe) id: number,
+    @GetUser() user: UserEntity,
+  ) {
+    return await this.tagFoldersService.deleteFolder(id, user);
   }
 }

--- a/src/tag_folders/tag_folders.repository.ts
+++ b/src/tag_folders/tag_folders.repository.ts
@@ -13,11 +13,11 @@ export class TagFoldersRepository {
     private dataSource: DataSource,
   ) {}
 
-  async getAllFolder(user_id: number) {
+  async getAllFolder(user: UserEntity) {
     return await this.dataSource
       .getRepository(TagFolderEntity)
       .createQueryBuilder('tag_folders')
-      .where('tag_folders.user_id = :user_id', { user_id })
+      .where('tag_folders.user_id = :user_id', { user_id: user.id })
       .leftJoinAndSelect('tag_folders.tags', 'tags')
       .leftJoin('tags.posts', 'posts')
       .orderBy('tag_folders.name', 'ASC')

--- a/src/tag_folders/tag_folders.service.ts
+++ b/src/tag_folders/tag_folders.service.ts
@@ -20,22 +20,19 @@ export class TagFoldersService {
     private tagRepository: Repository<TagEntity>,
   ) {}
 
-  async getAllFolder() {
-    const user_id = 1;
-
-    return await this.tagFoldersRepository.getAllFolder(user_id);
+  async getAllFolder(user: UserEntity) {
+    return await this.tagFoldersRepository.getAllFolder(user);
   }
 
-  async createFolder(body: TagFolderRequestDto) {
+  async createFolder(body: TagFolderRequestDto, user: UserEntity) {
     const { name } = body;
-    const user_id = 1;
 
-    const user = await this.usersRepository.findOne({
-      where: { id: user_id },
-    });
+    if (name.length === 0) {
+      throw new BadRequestException(`Can't make folder for empty name`);
+    }
 
     if (!user) {
-      throw new NotFoundException(`Can't find user with user_id: ${user_id}`);
+      throw new NotFoundException(`Can't find user with user_id: ${user.id}`);
     }
 
     const found = await this.tagFoldersRepository.getOneFolderByUserId(
@@ -50,13 +47,8 @@ export class TagFoldersService {
     return await this.tagFoldersRepository.createFolder(name, user);
   }
 
-  async updateFolder(id: number, body: TagFolderRequestDto) {
+  async updateFolder(id: number, body: TagFolderRequestDto, user: UserEntity) {
     const { name } = body;
-    const user_id = 1;
-
-    const user = await this.usersRepository.findOne({
-      where: { id: user_id },
-    });
 
     const found = await this.tagFoldersRepository.getOneFolderById(id, user);
 
@@ -67,13 +59,7 @@ export class TagFoldersService {
     return await this.tagFoldersRepository.updateFolder(id, name);
   }
 
-  async deleteFolder(id: number) {
-    const user_id = 1;
-
-    const user = await this.usersRepository.findOne({
-      where: { id: user_id },
-    });
-
+  async deleteFolder(id: number, user: UserEntity) {
     const found = await this.tagFoldersRepository.getOneFolderById(id, user);
 
     if (!found) {

--- a/src/tags/tags.controller.ts
+++ b/src/tags/tags.controller.ts
@@ -1,3 +1,4 @@
+import { UserEntity } from 'src/entities/users.entity';
 import { SkipThrottle } from '@nestjs/throttler';
 import { TagsService } from './tags.service';
 import {
@@ -8,32 +9,32 @@ import {
   ParseIntPipe,
   Post,
   Put,
+  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { SuccessInterceptor } from 'src/common/interceptors/success.interceptor';
 import { ApiOperation } from '@nestjs/swagger';
 import { TagRequestDto } from './tag.request.dto';
+import { JwtAuthGuard } from 'src/auth/guards/auth.guard';
+import { GetUser } from 'src/auth/auth.decorator';
 
 @SkipThrottle()
 @Controller('tags')
 @UseInterceptors(SuccessInterceptor)
+@UseGuards(JwtAuthGuard)
 export class TagsController {
   constructor(private readonly tagsService: TagsService) {}
 
   @ApiOperation({ summary: '전체 tag 조회' })
   @Get()
-  async getAllTag() {
-    const user_id = 1;
-
-    return await this.tagsService.getAllTag(user_id);
+  async getAllTag(@GetUser() user: UserEntity) {
+    return await this.tagsService.getAllTag(user);
   }
 
   @ApiOperation({ summary: 'tag 생성' })
   @Post()
-  async createTag(@Body() body: TagRequestDto) {
-    const user_id = 1;
-
-    return await this.tagsService.createTag(user_id, body);
+  async createTag(@Body() body: TagRequestDto, @GetUser() user: UserEntity) {
+    return await this.tagsService.createTag(user, body);
   }
 
   @ApiOperation({ summary: 'tag 수정' })
@@ -41,9 +42,8 @@ export class TagsController {
   async updateTag(
     @Param('tag_id', ParseIntPipe) tag_id: number,
     @Param('folder_id', ParseIntPipe) folder_id: number,
+    @GetUser() user: UserEntity,
   ) {
-    const user_id = 1;
-
-    return await this.tagsService.updateTag(user_id, tag_id, folder_id);
+    return await this.tagsService.updateTag(user, tag_id, folder_id);
   }
 }

--- a/src/tags/tags.repository.ts
+++ b/src/tags/tags.repository.ts
@@ -13,12 +13,12 @@ export class TagsRepository {
     private dataSource: DataSource,
   ) {}
 
-  async getAllTag(user_id) {
+  async getAllTag(user: UserEntity) {
     return await this.dataSource
       .getRepository(TagEntity)
       .createQueryBuilder('tags')
       .leftJoin('tags.posts', 'posts')
-      .where('posts.user_id = :user_id', { user_id })
+      .where('posts.user_id = :user_id', { user_id: user.id })
       .orderBy('tags.name', 'ASC')
       .loadRelationCountAndMap('tags.postsCount', 'tags.posts')
       .getMany();

--- a/src/tags/tags.service.ts
+++ b/src/tags/tags.service.ts
@@ -9,7 +9,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { UserEntity } from 'src/entities/users.entity';
 import { Repository } from 'typeorm';
 import { TagsRepository } from './tags.repository';
-import { TagFolderEntity } from 'src/entities/tagFolders.entity';
 
 @Injectable()
 export class TagsService {
@@ -17,23 +16,18 @@ export class TagsService {
     @InjectRepository(UserEntity)
     private userRepository: Repository<UserEntity>,
     private readonly tagsRepository: TagsRepository,
-    @InjectRepository(TagFolderEntity)
-    private tagFolderRepository: Repository<TagFolderEntity>,
-    private tagFoldersRepository: TagFoldersRepository,
+    private readonly tagFoldersRepository: TagFoldersRepository,
   ) {}
 
-  async getAllTag(user_id) {
-    return await this.tagsRepository.getAllTag(user_id);
+  async getAllTag(user: UserEntity) {
+    return await this.tagsRepository.getAllTag(user);
   }
 
-  async createTag(user_id: number, body: TagRequestDto) {
+  async createTag(user: UserEntity, body: TagRequestDto) {
     const { name } = body;
-    const user = await this.userRepository.findOne({
-      where: { id: user_id },
-    });
 
     if (!user) {
-      throw new NotFoundException(`Can't find user with user_id: ${user_id}`);
+      throw new NotFoundException(`Can't find user with user_id: ${user.id}`);
     }
 
     const found = await this.tagsRepository.getOneTagByName(user, name);
@@ -45,13 +39,9 @@ export class TagsService {
     return await this.tagsRepository.createTag(name);
   }
 
-  async updateTag(user_id: number, tag_id: number, folder_id: number) {
-    const user = await this.userRepository.findOne({
-      where: { id: user_id },
-    });
-
+  async updateTag(user: UserEntity, tag_id: number, folder_id: number) {
     if (!user) {
-      throw new NotFoundException(`Can't find user with user_id: ${user_id}`);
+      throw new NotFoundException(`Can't find user with user_id: ${user.id}`);
     }
 
     const foundTag = await this.tagsRepository.getOneTagById(user, tag_id);

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -9,8 +9,8 @@ import { UsersService } from './users.service';
 @UseInterceptors(SuccessInterceptor)
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
-    
-  @ApiOperation({ summary: '유저 정보 조회'})
+
+  @ApiOperation({ summary: '유저 정보 조회' })
   @UseGuards(JwtAuthGuard)
   @Get('/info')
   getUserInfo(@GetUser() id) {

--- a/src/users/users.dto.ts
+++ b/src/users/users.dto.ts
@@ -1,25 +1,23 @@
 import { IsString } from 'class-validator';
 
 export class GithubUserDto {
-    @IsString()
-    readonly githubId: string;
+  @IsString()
+  readonly githubId: string;
 
-    @IsString()
-    readonly avatar: string;
+  @IsString()
+  readonly avatar: string;
 
-    @IsString()
-    readonly name: string;
+  @IsString()
+  readonly name: string;
 
-    @IsString()
-    readonly description: string;
+  @IsString()
+  readonly description: string;
 
-    @IsString()
-    readonly location: string;
-  }
+  @IsString()
+  readonly location: string;
+}
 
-  export class GithubCodeDto {
-    @IsString()
-    readonly code: string;
-  }
-
-  
+export class GithubCodeDto {
+  @IsString()
+  readonly code: string;
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -6,9 +6,7 @@ import { UserEntity } from 'src/entities/users.entity';
 import { UsersRepository } from './users.repository';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([UserEntity, UsersRepository]),
-  ],
+  imports: [TypeOrmModule.forFeature([UserEntity, UsersRepository])],
   controllers: [UsersController],
   providers: [UsersService, UsersRepository],
 })

--- a/src/users/users.repository.ts
+++ b/src/users/users.repository.ts
@@ -9,28 +9,28 @@ export class UsersRepository {
     @InjectRepository(UserEntity)
     private usersRepository: Repository<UserEntity>,
   ) {}
-  
+
   async createUser(
     name: string,
     github_id: string,
     refresh_token: string | null,
     description: string,
-    profile_image: string
+    profile_image: string,
   ) {
     const user = this.usersRepository.create({
       name,
       github_id,
       refresh_token,
       description,
-      profile_image
+      profile_image,
     });
-    
+
     await this.usersRepository.save(user);
-    
+
     return user;
   }
 
-  async getOneUserByGithubId( github_id: string ) {
+  async getOneUserByGithubId(github_id: string) {
     return await this.usersRepository.findOne({
       where: {
         github_id,
@@ -38,23 +38,29 @@ export class UsersRepository {
     });
   }
 
-  async getOneUserById( id: number ) {
+  async getOneUserById(id: number) {
     return await this.usersRepository.findOne({
-      where: { 
+      where: {
         id,
-      }
+      },
     });
   }
 
   async updateRefreshTokenInUser(id: number, refresh_token: string) {
-    return await this.usersRepository.update({ id }, {
-      refresh_token
-    });
+    return await this.usersRepository.update(
+      { id },
+      {
+        refresh_token,
+      },
+    );
   }
 
   async deleteRefreshTokenInUser(id: number, refresh_token) {
-    return await this.usersRepository.update({ id }, {
-      refresh_token: null
-    });
+    return await this.usersRepository.update(
+      { id },
+      {
+        refresh_token: null,
+      },
+    );
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -4,14 +4,12 @@ import { UsersRepository } from './users.repository';
 
 @Injectable()
 export class UsersService {
-  constructor(
-    private readonly usersRepository: UsersRepository,
-  ) {}
-  
+  constructor(private readonly usersRepository: UsersRepository) {}
+
   async getUserInfo(id: number): Promise<UserEntity> {
     const found = this.usersRepository.getOneUserById(id);
 
-    if (!found){
+    if (!found) {
       throw new NotFoundException(`Can't find user with id: ${id}`);
     }
 


### PR DESCRIPTION
## 연관 이슈

<!-- 연관된 이슈의 링크와 내용을 아래 기입하세요(ex: Jira, Sentry 등의 이슈 링크) -->

## 풀리퀘스트 유형

<!-- [x] 로 체크 -->

- [ ] 버그수정
- [ ] 기능추가
- [x] 기능개선
- [ ] 기능삭제
- [ ] 리팩토링
- [ ] 기타 (우측에 설명기입): 

## 구현 사항

- 발급된 토큰으로부터 유저 정보를 가져오도 수정 :
 1. 회원가입/로그인 (토큰 발급) 기능이 구현됨에 따라 기존 posts, tags, tag_folders API의 유저 정보를 가져오는 로직을 수정함.
 2. JwtAuthGuard 에서 req.user = payload.id 에서 req.user = user : UserEntity의 정보가 담기도록 수정함.

- PostEntity 수정 :
 1. UserEntity가 구현됨에 따라 UserEntity와의 관계설정 및 PostEntity 수정함.

- 코드 컨벤션 통일

## 특이사항