### PR TITLE
🐛 fix: Apply default folder when tag is changed from update post API

### DIFF
--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -164,6 +164,9 @@ export class PostsService {
     }
 
     if (tags.length !== 0) {
+      const findDefaultFolder =
+        await this.tagfoldersrepository.getOneFolderByUserId('', user);
+
       for (const tag_name of tags) {
         const found = await this.dataSource
           .getRepository(TagEntity)
@@ -179,6 +182,7 @@ export class PostsService {
           const create = await this.tagsRepository.create({
             name: tag_name,
           });
+          create.folder_id = findDefaultFolder;
           await this.tagsRepository.save(create);
 
           updateTags = updateTags.concat(create);


### PR DESCRIPTION
## 연관 이슈

<!-- 연관된 이슈의 링크와 내용을 아래 기입하세요(ex: Jira, Sentry 등의 이슈 링크) -->

## 풀리퀘스트 유형

<!-- [x] 로 체크 -->

- [x] 버그수정
- [ ] 기능추가
- [ ] 기능개선
- [ ] 기능삭제
- [ ] 리팩토링
- [ ] 기타 (우측에 설명기입): 

## 구현 사항

- 게시글 수정으로 인한 tag 생성 관련 버그 :
 1. 게시글 수정 API로 tag가 생성 될 때, 디폴트 폴더가 적용되지 않던 문제 해결.

## 특이사항