### PR TITLE
🐛 fix: server shutdown error in refresh API

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -49,7 +49,7 @@ export class AuthController {
     @Headers('refreshToken') refreshToken: string,
     @GetUser() user: UserEntity,
   ) {
-    if (this.authService.validationRefreshToken(refreshToken, user.github_id)) {
+    if (await this.authService.validationRefreshToken(refreshToken, user)) {
       const accessToken = await this.authService.createAccessToken(user.id);
 
       return accessToken;

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -9,6 +9,7 @@ import axios, { AxiosResponse } from 'axios';
 import { UsersRepository } from '../users/users.repository';
 import { GithubCodeDto, GithubUserDto } from '../users/users.dto';
 import { Response } from 'express';
+import { UserEntity } from 'src/entities/users.entity';
 
 @Injectable()
 export class AuthService {
@@ -106,9 +107,7 @@ export class AuthService {
     return refreshToken;
   }
 
-  async validationRefreshToken(refreshToken: string, github_id: string) {
-    const user = await this.usersRepository.getOneUserByGithubId(github_id);
-
+  async validationRefreshToken(refreshToken: string, user: UserEntity) {
     if (refreshToken !== user.refresh_token) {
       throw new UnauthorizedException('error.refreshTokenvailed');
     }


### PR DESCRIPTION
## 연관 이슈

<!-- 연관된 이슈의 링크와 내용을 아래 기입하세요(ex: Jira, Sentry 등의 이슈 링크) -->

## 풀리퀘스트 유형

<!-- [x] 로 체크 -->

- [x] 버그수정
- [ ] 기능추가
- [ ] 기능개선
- [ ] 기능삭제
- [ ] 리팩토링
- [ ] 기타 (우측에 설명기입): 

## 구현 사항

- refresh api 에러시 서버가 꺼지던 에러  :
 1. DB에 있는 refresh token과 요청으로 보낸 refresh token이 일치하지 않을 시 에러코드와 함께 서버가 꺼지는 현상 해결

## 특이사항